### PR TITLE
feat: run policy checks on draftplan

### DIFF
--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -88,23 +88,23 @@ func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []stri
 		return output, err
 	}
 
-	if ctx.CommandName != command.DraftPlan {
-		// If using remote ops, we create our own "fake" planfile with the
-		// text output of the plan. We do this for two reasons:
-		// 1) Atlantis relies on there being a planfile on disk to detect which
-		// projects have outstanding plans.
-		// 2) Remote ops don't support the -out parameter so we can't save the
-		// plan. To ensure that what gets applied is the plan we printed to the PR,
-		// during the apply phase, we diff the output we stored in the fake
-		// planfile with the pending apply output.
-		planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
+	// If using remote ops, we create our own "fake" planfile with the
+	// text output of the plan. We do this for three reasons:
+	// 1) Atlantis relies on there being a planfile on disk to detect which
+	// projects have outstanding plans.
+	// 2) Remote ops don't support the -out parameter so we can't save the
+	// plan. To ensure that what gets applied is the plan we printed to the PR,
+	// during the apply phase, we diff the output we stored in the fake
+	// planfile with the pending apply output.
+	// 3) The show/policy_check steps need a planfile on disk to run
+	// "terraform show" against, including for draftplan.
+	planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
 
-		// We also prepend our own remote ops header to the file so during apply we
-		// know this is a remote apply.
-		err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
-		if err != nil {
-			return output, errors.Wrap(err, "unable to create planfile for remote ops")
-		}
+	// We also prepend our own remote ops header to the file so during apply we
+	// know this is a remote apply.
+	err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
+	if err != nil {
+		return output, errors.Wrap(err, "unable to create planfile for remote ops")
 	}
 
 	return p.fmtPlanOutput(output, tfVersion), nil
@@ -127,7 +127,7 @@ func (p *planStepRunner) buildPlanCmd(ctx command.ProjectContext, extraArgs []st
 	// have spaces in its repo owner names.
 	baseCommand := []string{"plan", "-input=false", "-refresh", "-out", fmt.Sprintf("%q", planFile)}
 	if ctx.CommandName == command.DraftPlan {
-		baseCommand = []string{"plan", "-input=false", "-refresh=false", "-lock=false"}
+		baseCommand = []string{"plan", "-input=false", "-refresh=false", "-lock=false", "-out", fmt.Sprintf("%q", planFile)}
 	}
 
 	argList := [][]string{

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -472,6 +472,131 @@ Plan: 0 to add, 0 to change, 1 to destroy.`), "expect plan success")
 	}
 }
 
+func TestRun_DraftPlan(t *testing.T) {
+	// DraftPlan should skip refresh and locking but still write a planfile
+	// via -out so that show/policy_check have something to read.
+	RegisterMockTestingT(t)
+	terraform := mocks.NewMockClient()
+	commitStatusUpdater := runtimemocks.NewMockStatusUpdater()
+	asyncTfExec := runtimemocks.NewMockAsyncTFExec()
+
+	tfVersion, _ := version.NewVersion("1.0.0")
+	logger := logging.NewNoopLogger(t)
+	s := runtime.NewPlanStepRunner(terraform, tfVersion, commitStatusUpdater, asyncTfExec)
+	tmpDir := t.TempDir()
+
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh=false",
+		"-lock=false",
+		"-out",
+		fmt.Sprintf("%q", filepath.Join(tmpDir, "workspace.tfplan")),
+		"extra",
+		"args",
+		"comment",
+		"args",
+	}
+	ctx := command.ProjectContext{
+		Log:                logger,
+		CommandName:        command.DraftPlan,
+		Workspace:          "workspace",
+		RepoRelDir:         ".",
+		User:               models.User{Username: "username"},
+		EscapedCommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+			Owner:    "owner",
+			Name:     "repo",
+		},
+	}
+	When(terraform.RunCommandWithVersion(ctx, tmpDir, expPlanArgs, map[string]string(nil), tfVersion, "workspace")).ThenReturn("output", nil)
+
+	output, err := s.Run(ctx, []string{"extra", "args"}, tmpDir, map[string]string(nil))
+	Ok(t, err)
+
+	terraform.VerifyWasCalledOnce().RunCommandWithVersion(ctx, tmpDir, expPlanArgs, map[string]string(nil), tfVersion, "workspace")
+	Equals(t, "output", output)
+}
+
+func TestRun_RemoteOps_DraftPlan(t *testing.T) {
+	// Even for remote ops, draftplan must leave a (fake) planfile on disk so
+	// that show/policy_check have something to read, unlike before when
+	// draftplan skipped writing it entirely.
+	logger := logging.NewNoopLogger(t)
+	ctx := command.ProjectContext{
+		Log:                logger,
+		CommandName:        command.DraftPlan,
+		Workspace:          "default",
+		RepoRelDir:         ".",
+		User:               models.User{Username: "username"},
+		EscapedCommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+			Owner:    "owner",
+			Name:     "repo",
+		},
+	}
+	RegisterMockTestingT(t)
+	terraform := mocks.NewMockClient()
+	commitStatusUpdater := runtimemocks.NewMockStatusUpdater()
+	tfVersion, _ := version.NewVersion("1.1.0")
+	asyncTf := &remotePlanMock{}
+	s := runtime.NewPlanStepRunner(terraform, tfVersion, commitStatusUpdater, asyncTf)
+	absProjectPath := t.TempDir()
+
+	When(terraform.RunCommandWithVersion(
+		ctx,
+		absProjectPath,
+		[]string{"workspace", "show"},
+		map[string]string(nil),
+		tfVersion,
+		"default")).ThenReturn("default\n", nil)
+
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh=false",
+		"-lock=false",
+		"-out",
+		fmt.Sprintf("%q", filepath.Join(absProjectPath, "default.tfplan")),
+		"extra",
+		"args",
+		"comment",
+		"args",
+	}
+
+	remoteOpsErr := strings.Join([]string{
+		"╷",
+		"│ Error: Saving a generated plan is currently not supported",
+		"│ ",
+		"│ Terraform Cloud does not support saving the generated execution plan",
+		"│ locally at this time.",
+		"╵",
+		"",
+	}, "\n")
+	planErr := errors.New("exit status 1: err")
+	planOutput := "\n" + remoteOpsErr
+	asyncTf.LinesToSend = remotePlanOutput
+	When(terraform.RunCommandWithVersion(ctx, absProjectPath, expPlanArgs, map[string]string(nil), tfVersion, "default")).
+		ThenReturn(planOutput, planErr)
+
+	_, err := s.Run(ctx, []string{"extra", "args"}, absProjectPath, map[string]string(nil))
+	Ok(t, err)
+
+	expRemotePlanArgs := []string{"plan", "-input=false", "-no-color", "-refresh=false", "-lock=false", "extra", "args", "comment", "args"}
+	Equals(t, expRemotePlanArgs, asyncTf.CalledArgs)
+
+	// Verify that the fake plan file still gets written for draftplan.
+	bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.tfplan"))
+	Ok(t, err)
+	Assert(t, strings.HasPrefix(string(bytes), "Atlantis: this plan was created by remote ops"), "expect remote plan")
+}
+
 // Test striping output method
 func TestStripRefreshingFromPlanOutput(t *testing.T) {
 	tfVersion0135, _ := version.NewVersion("0.13.5")

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -199,7 +199,9 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 	var numErrored int
 	status := models.SuccessCommitStatus
 
-	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+	// A draftplan with no changes has nothing to apply, same as a real
+	// plan with no changes, so it counts toward success here too.
+	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 	numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 	if numErrored > 0 {

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -72,6 +72,9 @@ type ProjectContext struct {
 	PullReqStatus models.PullReqStatus
 	// CurrentProjectPlanStatus is the status of the current project prior to this command.
 	ProjectPlanStatus models.ProjectPlanStatus
+	// IsDraftPlan is true if this stage was triggered by a draftplan command
+	// (or the policy_check that followed one) rather than a full plan.
+	IsDraftPlan bool
 	//PullStatus is the status of the current pull request prior to this command.
 	PullStatus *models.PullStatus
 	// ProjectPolicyStatus is the status of policy sets of the current project prior to this command.

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -52,7 +52,7 @@ func (p ProjectResult) PolicyStatus() []models.PolicySetStatus {
 func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 	switch p.Command {
 
-	case Plan, DraftPlan:
+	case Plan:
 		if p.Error != nil {
 			return models.ErroredPlanStatus
 		} else if p.Failure != "" {
@@ -61,6 +61,15 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 			return models.PlannedNoChangesPlanStatus
 		}
 		return models.PlannedPlanStatus
+	case DraftPlan:
+		if p.Error != nil {
+			return models.ErroredPlanStatus
+		} else if p.Failure != "" {
+			return models.ErroredPlanStatus
+		} else if p.PlanSuccess.NoChanges() {
+			return models.DraftPlannedNoChangesPlanStatus
+		}
+		return models.DraftPlannedPlanStatus
 	case PolicyCheck, ApprovePolicies:
 		if p.Error != nil {
 			return models.ErroredPolicyCheckStatus

--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -90,6 +90,29 @@ func TestProjectResult_PlanStatus(t *testing.T) {
 		},
 		{
 			p: command.ProjectResult{
+				Command: command.DraftPlan,
+				Error:   errors.New("err"),
+			},
+			expStatus: models.ErroredPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
+				Command:     command.DraftPlan,
+				PlanSuccess: &models.PlanSuccess{},
+			},
+			expStatus: models.DraftPlannedPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
+				Command: command.DraftPlan,
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: "No changes. Infrastructure is up-to-date.",
+				},
+			},
+			expStatus: models.DraftPlannedNoChangesPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
 				Command: command.Apply,
 				Error:   errors.New("err"),
 			},

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -43,6 +43,13 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
+	// A draftplan is an unlocked, unrefreshed preview and must never be
+	// applied. Its plan status is distinct from a real plan's, so this
+	// check can't be bypassed by configuring apply_requirements.
+	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
+		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
+	}
+
 	for _, req := range ctx.ApplyRequirements {
 		switch req {
 		case raw.ApprovedRequirement:

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -43,9 +43,13 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
-	// A draftplan is an unlocked, unrefreshed preview and must never be
-	// applied. Its plan status is distinct from a real plan's, so this
-	// check can't be bypassed by configuring apply_requirements.
+	// Blocks apply while the project's last recorded status is still a
+	// draftplan (an unlocked, unrefreshed preview). This only covers the
+	// window before a policy_check has run against it: once policy_check
+	// runs, it overwrites the recorded status, and apply is gated by the
+	// normal apply_requirements (mergeable/approved/policies-passed) tied
+	// to a subsequent real plan instead. Runs before the loop below so it
+	// can't be disabled by apply_requirements config.
 	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
 		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
 	}

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -190,6 +190,29 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
 		},
+		{
+			name: "fail by draft planned with changes, even with no apply requirements configured",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.DraftPlannedPlanStatus,
+			},
+			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "fail by draft planned with no changes",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.DraftPlannedNoChangesPlanStatus,
+			},
+			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "pass when a real plan followed the draft plan",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.PlannedPlanStatus,
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1198,6 +1198,130 @@ $$$
 	}
 }
 
+func TestRenderProjectResults_DraftPlanPolicyCheck(t *testing.T) {
+	cases := []struct {
+		Description    string
+		ProjectResults []command.ProjectResult
+		Expected       string
+	}{
+		{
+			"draftplan policy check cleared shows no apply/replan CTA",
+			[]command.ProjectResult{
+				{
+					PolicyCheckResults: &models.PolicyCheckResults{
+						PolicySetResults: []models.PolicySetResult{
+							{
+								PolicySetName: "policy1",
+								PolicyOutput:  "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions",
+								Passed:        true,
+								ReqApprovals:  1,
+							},
+						},
+						LockURL:     "lock-url",
+						RePlanCmd:   "atlantis plan -d path -w workspace",
+						ApplyCmd:    "atlantis apply -d path -w workspace",
+						IsDraftPlan: true,
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			`
+Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
+
+#### Policy Set: $policy1$
+$$$diff
+2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions
+$$$
+
+
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
+`,
+		},
+		{
+			"draftplan policy check with violations shows approval status but no apply CTA",
+			[]command.ProjectResult{
+				{
+					PolicyCheckResults: &models.PolicyCheckResults{
+						PolicySetResults: []models.PolicySetResult{
+							{
+								PolicySetName: "policy1",
+								PolicyOutput:  "FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.",
+								Passed:        false,
+								ReqApprovals:  1,
+							},
+						},
+						LockURL:            "lock-url",
+						RePlanCmd:          "atlantis plan -d path -w workspace",
+						ApplyCmd:           "atlantis apply -d path -w workspace",
+						ApprovePoliciesCmd: "atlantis approve_policies -d path -w workspace",
+						IsDraftPlan:        true,
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			`
+Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
+
+#### Policy Set: $policy1$
+$$$diff
+FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
+$$$
+
+
+#### Policy Approval Status:
+$$$
+policy set: policy1: requires: 1 approval(s), have: 0.
+$$$
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
+`,
+		},
+	}
+
+	r := events.NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false)
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := command.Result{ProjectResults: c.ProjectResults}
+			cmd := &events.CommentCommand{Name: command.PolicyCheck}
+			s := r.Render(ctx, res, cmd)
+			Equals(t, normalize(c.Expected), normalize(s))
+		})
+	}
+}
+
 // Test that if disable apply all is set then the apply all footer is not added
 func TestRenderProjectResultsDisableApplyAll(t *testing.T) {
 	cases := []struct {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -459,6 +459,9 @@ type PolicyCheckResults struct {
 	// branch we're merging into has been updated since we cloned and merged
 	// it.
 	HasDiverged bool
+	// IsDraftPlan is true if this policy check ran against a draftplan
+	// preview rather than a full plan, in which case ApplyCmd is not usable.
+	IsDraftPlan bool
 }
 
 // ImportSuccess is the result of a successful import run.
@@ -589,6 +592,14 @@ const (
 	// PassedPolicyCheckStatus means that there was an unapplied plan that was
 	// discarded due to a project being unlocked
 	PassedPolicyCheckStatus
+	// DraftPlannedPlanStatus means that a draftplan has been successfully
+	// generated with changes. Unlike PlannedPlanStatus, this plan was not
+	// taken under a lock or against refreshed state, so it cannot be applied.
+	DraftPlannedPlanStatus
+	// DraftPlannedNoChangesPlanStatus means that a draftplan has been
+	// successfully generated with "No changes". Like DraftPlannedPlanStatus,
+	// this cannot be applied.
+	DraftPlannedNoChangesPlanStatus
 )
 
 // String returns a string representation of the status.
@@ -610,6 +621,10 @@ func (p ProjectPlanStatus) String() string {
 		return "policy_check_errored"
 	case PassedPolicyCheckStatus:
 		return "policy_check_passed"
+	case DraftPlannedPlanStatus:
+		return "draft_planned"
+	case DraftPlannedNoChangesPlanStatus:
+		return "draft_planned_no_changes"
 	default:
 		panic("missing String() impl for ProjectPlanStatus")
 	}

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -288,11 +288,13 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.
-	if cmd.Name == command.Plan && len(result.ProjectResults) > 0 &&
+	// Draftplan also runs policy checks so that violations are visible
+	// before a real, locked plan is ever generated.
+	if (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && len(result.ProjectResults) > 0 &&
 		!(result.HasErrors() || result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for %s", cmd.String())
 		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
-	} else if len(projectCmds) == 0 && cmd.Name == command.Plan && !cmd.IsForSpecificProject() {
+	} else if len(projectCmds) == 0 && (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && !cmd.IsForSpecificProject() {
 		// If there were no projects modified, we set successful commit statuses
 		// with 0/0 projects planned/policy_checked/applied successfully because some users require
 		// the Atlantis status to be passing for all pull requests.

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -149,7 +149,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 	}
 
 	p.updateCommitStatus(ctx, pullStatus, command.Plan)
-	p.updateCommitStatus(ctx, pullStatus, command.Apply) // @@@ check drafplan here
+	p.updateCommitStatus(ctx, pullStatus, command.Apply)
 
 	// Check if there are any planned projects and if there are any errors or if plans are being deleted
 	if len(policyCheckCmds) > 0 &&
@@ -286,10 +286,8 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		p.updateCommitStatus(ctx, pullStatus, command.Apply)
 	}
 
-	// Runs policy checks step after all plans are successful.
+	// Runs policy checks step after all plans and draftplans are successful.
 	// This step does not approve any policies that require approval.
-	// Draftplan also runs policy checks so that violations are visible
-	// before a real, locked plan is ever generated.
 	if (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && len(result.ProjectResults) > 0 &&
 		!(result.HasErrors() || result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for %s", cmd.String())
@@ -329,7 +327,7 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 			status = models.FailedCommitStatus
 		}
 	} else if commandName == command.Apply {
-		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 		numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 		if numErrored > 0 {

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -155,6 +155,57 @@ func TestPlanCommandRunner_IsSilenced(t *testing.T) {
 	}
 }
 
+func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
+	RegisterMockTestingT(t)
+	setup(t)
+
+	logger := logging.NewNoopLogger(t)
+	scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.DraftPlan}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{
+		{CommandName: command.DraftPlan, RepoRelDir: "somedir", Workspace: "default"},
+		{CommandName: command.PolicyCheck, RepoRelDir: "somedir", Workspace: "default"},
+	}, nil)
+	When(projectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(command.ProjectResult{
+		Command:     command.DraftPlan,
+		PlanSuccess: &models.PlanSuccess{},
+		RepoRelDir:  "somedir",
+		Workspace:   "default",
+	})
+	When(projectCommandRunner.PolicyCheck(Any[command.ProjectContext]())).ThenReturn(command.ProjectResult{
+		Command:            command.PolicyCheck,
+		PolicyCheckResults: &models.PolicyCheckResults{},
+		RepoRelDir:         "somedir",
+		Workspace:          "default",
+	})
+
+	planCommandRunner.Run(ctx, cmd)
+
+	// A draftplan should still run the policy_check step for its projects,
+	// same as a real plan would, so violations surface before a real,
+	// locked plan is ever generated.
+	projectCommandRunner.VerifyWasCalledOnce().PolicyCheck(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.PolicyCheck),
+		Eq(1),
+		Eq(1),
+	)
+}
+
 func TestPlanCommandRunner_ExecutionOrder(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -191,9 +191,6 @@ func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
 
 	planCommandRunner.Run(ctx, cmd)
 
-	// A draftplan should still run the policy_check step for its projects,
-	// same as a real plan would, so violations surface before a real,
-	// locked plan is ever generated.
 	projectCommandRunner.VerifyWasCalledOnce().PolicyCheck(Any[command.ProjectContext]())
 	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
 		Any[logging.SimpleLogging](),
@@ -203,6 +200,66 @@ func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
 		Eq[command.Name](command.PolicyCheck),
 		Eq(1),
 		Eq(1),
+	)
+}
+
+func TestPlanCommandRunner_ApplyStatusCountsDraftPlanNoChanges(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	tmp := t.TempDir()
+	backend, err := db.New(tmp)
+	Ok(t, err)
+
+	setup(t, func(tc *TestConfig) {
+		tc.backend = backend
+	})
+
+	logger := logging.NewNoopLogger(t)
+	scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	// "draftdir" only ever had a "no changes" draftplan; it will never get
+	// a real plan or apply, and shouldn't permanently block the PR's Apply
+	// status from going green.
+	_, err = backend.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:     command.DraftPlan,
+			RepoRelDir:  "draftdir",
+			Workspace:   "default",
+			PlanSuccess: &models.PlanSuccess{TerraformOutput: "No changes. Infrastructure is up-to-date."},
+		},
+	})
+	Ok(t, err)
+
+	When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{
+		{CommandName: command.Plan, RepoRelDir: "mydir", Workspace: "default"},
+	}, nil)
+	When(projectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(command.ProjectResult{
+		Command:     command.Plan,
+		RepoRelDir:  "mydir",
+		Workspace:   "default",
+		PlanSuccess: &models.PlanSuccess{TerraformOutput: "No changes. Infrastructure is up-to-date."},
+	})
+
+	planCommandRunner.Run(ctx, cmd)
+
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.Apply),
+		Eq(2),
+		Eq(2),
 	)
 }
 

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -145,6 +145,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 		ctx.Scope,
 		ctx.PullRequestStatus,
 		ctx.PullStatus,
+		cmdName == command.DraftPlan,
 	)
 
 	projectCmds = append(projectCmds, projectCmdContext)
@@ -195,7 +196,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 		terraformClient,
 	)
 
-	if cmdName == command.Plan && prjCfg.PolicyCheck {
+	if (cmdName == command.Plan || cmdName == command.DraftPlan) && prjCfg.PolicyCheck {
 		ctx.Log.Debug("Building project command context for %s", command.PolicyCheck)
 		steps := prjCfg.Workflow.PolicyCheck.Steps
 
@@ -217,6 +218,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 			ctx.Scope,
 			ctx.PullRequestStatus,
 			ctx.PullStatus,
+			cmdName == command.DraftPlan,
 		))
 	}
 
@@ -242,6 +244,7 @@ func newProjectCommandContext(ctx *command.Context,
 	scope tally.Scope,
 	pullReqStatus models.PullReqStatus,
 	pullStatus *models.PullStatus,
+	isDraftPlan bool,
 ) command.ProjectContext {
 
 	var projectPlanStatus models.ProjectPlanStatus
@@ -306,6 +309,7 @@ func newProjectCommandContext(ctx *command.Context,
 		JobID:                      uuid.New().String(),
 		ExecutionOrderGroup:        projCfg.ExecutionOrderGroup,
 		AbortOnExcecutionOrderFail: abortOnExcecutionOrderFail,
+		IsDraftPlan:                isDraftPlan,
 	}
 }
 

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -127,3 +127,58 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 		assert.True(t, result[0].AbortOnExcecutionOrderFail)
 	})
 }
+
+func TestPolicyCheckProjectCommandContextBuilder_BuildProjectContext(t *testing.T) {
+	mockCommentBuilder := mocks.NewMockCommentBuilder()
+	subject := events.PolicyCheckProjectCommandContextBuilder{
+		CommentBuilder:               mockCommentBuilder,
+		ProjectCommandContextBuilder: &events.DefaultProjectCommandContextBuilder{CommentBuilder: mockCommentBuilder},
+	}
+
+	projCfg := valid.MergedProjectCfg{
+		RepoRelDir:  "dir1",
+		Workspace:   "default",
+		Name:        "project1",
+		PolicyCheck: true,
+		Workflow: valid.Workflow{
+			Name: valid.DefaultWorkflowName,
+			Plan: valid.DefaultPlanStage,
+		},
+	}
+
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{}},
+	}
+
+	terraformClient := terraform_mocks.NewMockClient()
+
+	t.Run("plan with policy checks enabled builds a plan and a policy_check context", func(t *testing.T) {
+		result := subject.BuildProjectContext(commandCtx, command.Plan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, command.Plan, result[0].CommandName)
+		assert.False(t, result[0].IsDraftPlan)
+		assert.Equal(t, command.PolicyCheck, result[1].CommandName)
+		assert.False(t, result[1].IsDraftPlan)
+	})
+
+	t.Run("draftplan with policy checks enabled also builds a policy_check context, marked as draft", func(t *testing.T) {
+		result := subject.BuildProjectContext(commandCtx, command.DraftPlan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+		assert.True(t, result[0].IsDraftPlan)
+		assert.Equal(t, command.PolicyCheck, result[1].CommandName)
+		assert.True(t, result[1].IsDraftPlan)
+	})
+
+	t.Run("draftplan with policy checks disabled only builds the draftplan context", func(t *testing.T) {
+		disabledCfg := projCfg
+		disabledCfg.PolicyCheck = false
+		result := subject.BuildProjectContext(commandCtx, command.DraftPlan, "", disabledCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+	})
+}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -521,6 +521,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 		RePlanCmd:          ctx.RePlanCmd,
 		ApplyCmd:           ctx.ApplyCmd,
 		ApprovePoliciesCmd: ctx.ApprovePoliciesCmd,
+		IsDraftPlan:        ctx.IsDraftPlan,
 	}
 
 	// Using this function instead of catching failed policy runs with errors, for cases when '--no-fail' is passed to conftest.

--- a/server/events/templates/policy_check_results_unwrapped.tmpl
+++ b/server/events/templates/policy_check_results_unwrapped.tmpl
@@ -12,6 +12,15 @@
 ```
 {{ end -}}
 {{- end }}
+{{- if .IsDraftPlan }}
+{{- if not .PolicyCleared }}
+#### Policy Approval Status:
+```
+{{ .PolicyApprovalSummary }}
+```
+{{- end }}
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
+{{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
@@ -32,4 +41,5 @@
   ```shell
   {{ .RePlanCmd }}
   ```
+{{- end }}
 {{ end -}}

--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -13,6 +13,16 @@
 ```
 {{ end -}}
 {{- end }}
+{{- if .IsDraftPlan }}
+</details>
+{{- if not .PolicyCleared }}
+#### Policy Approval Status:
+```
+{{ .PolicyApprovalSummary }}
+```
+{{- end }}
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
+{{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
@@ -34,6 +44,7 @@
   ```shell
   {{ .RePlanCmd }}
   ```
+{{- end }}
 {{- if eq .Command "Policy Check" }}
 
 {{- if ne .PolicyCheckSummary "" }}


### PR DESCRIPTION
## Summary
- draftplan now writes a real planfile (`-out` locally, fake planfile for remote ops) so `show`/`policy_check` have something to evaluate, while still skipping `-refresh`/`-lock`.
- policy_check now runs after a successful draftplan, same as it does for a real plan, so rego violations show up in the draftplan preview instead of only appearing once a real plan runs. This reverses the exclusion added in 2b44cc68 ("only update policycheck/apply status on plan, not draftplan").
- Added `DraftPlannedPlanStatus`/`DraftPlannedNoChangesPlanStatus` so a draftplan's outcome is tracked separately from a real plan's. `ValidateApplyProject` blocks `atlantis apply` while a project's last recorded status is still one of these. This only covers projects without `policy_check` configured (or the brief window before policy_check runs) — once policy_check runs it overwrites the recorded status, and apply is gated the normal way from there: `apply_requirements` tied to a subsequent real plan.
- Per-project policy_check comment templates now check `IsDraftPlan` and show a warning + "run `atlantis plan`" instead of an `atlantis apply` command that would just be rejected.
- Fixed the Apply commit-status success count (`plan_command_runner.go`/`apply_command_runner.go`) to also count `DraftPlannedNoChangesPlanStatus`, same as it already does for a real plan's "no changes" status. Otherwise a project whose only result is a "no changes" draftplan would permanently keep the PR's Apply status stuck at pending.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo; the only failure, `TestGitHubWorkflowWithPolicyCheck`, reproduces identically on unmodified `cog2` and is a local-conftest-version flake, not caused by this change)
- [x] Added unit tests: plan_step_runner (draftplan args + remote-ops planfile), command_requirement_handler (apply guard), project_command_context_builder (policy_check context built for draftplan), plan_command_runner (draftplan triggers policy check, and that a "no changes" draftplan counts toward the Apply commit status), markdown_renderer (draft policy-check comment rendering)

## Known follow-up
The bulk "apply all unapplied plans" / "unlock" footer on multi/single-project policy-check comments still shows unconditionally (driven by aggregate PR-level data, not per-project draft origin). Not a safety issue since `ValidateApplyProject` blocks the actual apply regardless for the cases it covers, but a UX inconsistency worth a follow-up.
